### PR TITLE
Fix integer narrowing in contraction hierarchies

### DIFF
--- a/core/contraction.c
+++ b/core/contraction.c
@@ -51,11 +51,11 @@ CHPath* chpNewHollow( long length ) {
     return this;
 }
 
-int chpLength( CHPath* this ) {
+long chpLength( CHPath* this ) {
     if(!this) {
         return INFINITY;
     }
-    
+
     return this->length;
 }
 
@@ -89,7 +89,7 @@ Combination* pathToEdgePayload( CHPath* this ) {
     return ret;
 }
     
-CHPath* dist( Graph *gg, char* from_v_label, char* to_v_label, WalkOptions *wo, int weightlimit, int return_full_path )  {
+CHPath* dist( Graph *gg, char* from_v_label, char* to_v_label, WalkOptions *wo, long weightlimit, int return_full_path )  {
     if( strcmp( from_v_label, to_v_label ) == 0 ) {
         return NULL;
     }
@@ -171,7 +171,7 @@ CHPath** get_shortcuts( Graph *gg, Vertex* vv, WalkOptions* wo, int search_limit
     
     // GET PATHS c(v,w) FROM v to ALL ws, FINDING THE MAX c(v,w)
     CHPath** cvw = (CHPath**)malloc(n_ws*sizeof(CHPath*));
-    int max_cvw = -INFINITY;
+    long max_cvw = -INFINITY;
     for(i=0; i<n_ws; i++) {
         cvw[i] = dist( gg, vv->label, ws[i]->label, wo, INFINITY, TRUE );
         if( cvw[i] ) {
@@ -194,8 +194,8 @@ CHPath** get_shortcuts( Graph *gg, Vertex* vv, WalkOptions* wo, int search_limit
         //if the path c(u,v) is NULL, it means u==v; ignore
         if(cuv[i]) {
         
-            int cuv_length = chpLength( cuv[i] );
-            int weightlimit = cuv_length+max_cvw;
+            long cuv_length = chpLength( cuv[i] );
+            long weightlimit = cuv_length + max_cvw;
             
             //FOR EACH W
             for(j=0; j<n_ws; j++) {

--- a/core/contraction.h
+++ b/core/contraction.h
@@ -14,13 +14,13 @@ struct CH {
 
 CHPath* chpNew( int n, long length ) ;
 
-int chpLength( CHPath* this ) ;
+long chpLength( CHPath* this ) ;
 
 CHPath* chpCombine( CHPath* a, CHPath* b ) ;
 
 void chpDestroy( CHPath* this ) ;
     
-CHPath* dist( Graph *gg, char* from_v_label, char* to_v_label, WalkOptions *wo, int weightlimit, int return_full_path ) ;
+CHPath* dist( Graph *gg, char* from_v_label, char* to_v_label, WalkOptions *wo, long weightlimit, int return_full_path ) ;
 
 CHPath** get_shortcuts( Graph *gg, Vertex* vv, WalkOptions* wo, int search_limit, int* n ) ;
 

--- a/pygs/graphserver/gsdll.py
+++ b/pygs/graphserver/gsdll.py
@@ -151,13 +151,13 @@ LGSTypes.edgepayload_t = {1: c_int8, 2: c_int16, 4: c_int32, 8: c_int64}[
 ]
 declarations = [
     (lgs.chpNew, LGSTypes.CHPath, [c_int, c_long]),
-    (lgs.chpLength, c_int, [LGSTypes.CHPath]),
+    (lgs.chpLength, c_long, [LGSTypes.CHPath]),
     (lgs.chpCombine, LGSTypes.CHPath, [LGSTypes.CHPath, LGSTypes.CHPath]),
     (lgs.chpDestroy, None, [LGSTypes.CHPath]),
     (
         lgs.dist,
         LGSTypes.CHPath,
-        [LGSTypes.Graph, c_char_p, c_char_p, LGSTypes.WalkOptions, c_int, c_int],
+        [LGSTypes.Graph, c_char_p, c_char_p, LGSTypes.WalkOptions, c_long, c_int],
     ),
     (
         lgs.get_shortcuts,


### PR DESCRIPTION
## Summary
- avoid returning `int` from `chpLength` when the stored length is `long`
- update `dist` to take a `long` weight limit and propagate the change
- adjust Python bindings for new signatures

## Testing
- `make` *(fails: valgrind/callgrind.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6872b3f37d0083329fd17d5133f4d6e1