### PR TITLE
Reorder headway constructor params

### DIFF
--- a/core/edgetypes/headwayalight.c
+++ b/core/edgetypes/headwayalight.c
@@ -3,7 +3,9 @@
 // HEADWAYALIGHT FUNCTIONS
 
 HeadwayAlight*
-haNew(  ServiceId service_id, ServiceCalendar* calendar, Timezone* timezone, int agency, char* trip_id, int start_time, int end_time, int headway_secs ) {
+haNew(ServiceId service_id, char* trip_id,
+      ServiceCalendar* calendar, Timezone* timezone, int agency,
+      int start_time, int end_time, int headway_secs ) {
   HeadwayAlight* ret = (HeadwayAlight*)malloc(sizeof(HeadwayAlight));
   ret->external_id = 0;
   ret->type = PL_HEADWAYALIGHT;

--- a/core/edgetypes/headwayalight.h
+++ b/core/edgetypes/headwayalight.h
@@ -21,7 +21,9 @@ struct HeadwayAlight {
 };
 
 HeadwayAlight*
-haNew(  ServiceId service_id, ServiceCalendar* calendar, Timezone* timezone, int agency, char* trip_id, int start_time, int end_time, int headway_secs );
+haNew(ServiceId service_id, char* trip_id,
+      ServiceCalendar* calendar, Timezone* timezone, int agency,
+      int start_time, int end_time, int headway_secs );
 
 void
 haDestroy(HeadwayAlight* this);

--- a/core/edgetypes/headwayboard.c
+++ b/core/edgetypes/headwayboard.c
@@ -3,7 +3,9 @@
 // HEADWAYBOARD FUNCTIONS
 
 HeadwayBoard*
-hbNew(  ServiceId service_id, ServiceCalendar* calendar, Timezone* timezone, int agency, char* trip_id, int start_time, int end_time, int headway_secs ) {
+hbNew(ServiceId service_id, char* trip_id,
+      ServiceCalendar* calendar, Timezone* timezone, int agency,
+      int start_time, int end_time, int headway_secs ) {
   HeadwayBoard* ret = (HeadwayBoard*)malloc(sizeof(HeadwayBoard));
   ret->external_id = 0;
   ret->type = PL_HEADWAYBOARD;

--- a/core/edgetypes/headwayboard.h
+++ b/core/edgetypes/headwayboard.h
@@ -21,7 +21,9 @@ struct HeadwayBoard {
 } ;
 
 HeadwayBoard*
-hbNew(  ServiceId service_id, ServiceCalendar* calendar, Timezone* timezone, int agency, char* trip_id, int start_time, int end_time, int headway_secs );
+hbNew(ServiceId service_id, char* trip_id,
+      ServiceCalendar* calendar, Timezone* timezone, int agency,
+      int start_time, int end_time, int headway_secs);
 
 void
 hbDestroy(HeadwayBoard* this);

--- a/pygs/graphserver/core.py
+++ b/pygs/graphserver/core.py
@@ -1744,10 +1744,10 @@ class HeadwayBoard(EdgePayload):
 
         self.soul = self._cnew(
             service_id,
+            trip_id,
             calendar.soul,
             timezone.soul,
             agency,
-            trip_id,
             start_time,
             end_time,
             headway_secs,
@@ -1856,10 +1856,10 @@ class HeadwayAlight(EdgePayload):
 
         self.soul = self._cnew(
             service_id,
+            trip_id,
             calendar.soul,
             timezone.soul,
             agency,
-            trip_id,
             start_time,
             end_time,
             headway_secs,

--- a/pygs/graphserver/gsdll.py
+++ b/pygs/graphserver/gsdll.py
@@ -573,10 +573,10 @@ declarations = [
         LGSTypes.HeadwayAlight,
         [
             LGSTypes.ServiceId,
+            c_char_p,
             LGSTypes.ServiceCalendar,
             LGSTypes.Timezone,
             c_int,
-            c_char_p,
             c_int,
             c_int,
             c_int,
@@ -606,10 +606,10 @@ declarations = [
         LGSTypes.HeadwayBoard,
         [
             LGSTypes.ServiceId,
+            c_char_p,
             LGSTypes.ServiceCalendar,
             LGSTypes.Timezone,
             c_int,
-            c_char_p,
             c_int,
             c_int,
             c_int,


### PR DESCRIPTION
## Summary
- reorder arguments for `hbNew` and `haNew`
- update gsdll binding tables for new parameter order
- adjust `HeadwayBoard` and `HeadwayAlight` Python wrappers

## Testing
- `pytest -q` *(fails: unable to load libgraphserver)*

------
https://chatgpt.com/codex/tasks/task_e_6872b3e2edf88332ad41de0277e0d0fb