### PR TITLE
refactor: centralize OSM vertex creation

### DIFF
--- a/python/src/graphserver/providers/osm/access_provider.py
+++ b/python/src/graphserver/providers/osm/access_provider.py
@@ -20,6 +20,7 @@ from graphserver.core import (
     Vertex,
     VertexEdgePair,
 )
+from .utils import create_osm_node_vertex
 
 if TYPE_CHECKING:
     from .data_source import OSMDataSource
@@ -198,10 +199,7 @@ class OSMAccessProvider(CacheAwareEdgeProvider):
             self._linked_vertices[nearest_node.id].append(vertex_template)
 
             # Invalidate cache for the OSM node to ensure new edges are discovered
-            # Must use the same identity hash that the network provider would use
-            osm_node_data = {"osm_node_id": nearest_node.id}
-            identity_hash = self._get_identity_hash(osm_node_data)
-            osm_node_vertex = Vertex(osm_node_data, hash_value=identity_hash)
+            osm_node_vertex = create_osm_node_vertex(nearest_node.id)
             with contextlib.suppress(ValueError):
                 # Vertex not in cache yet, no need to invalidate
                 self.invalidate_vertex(osm_node_vertex)
@@ -305,16 +303,9 @@ class OSMAccessProvider(CacheAwareEdgeProvider):
         duration_s = distance_m / self.data_source.walking_profile.base_speed_ms
 
         # Create target vertex with OSM node information
-        target_data = {
-            "osm_node_id": node.id,
-        }
-
-        # Preserve time from origin vertex if present
-        if "time" in vertex:
-            target_data["time"] = vertex["time"]
-
-        identity_hash = self._get_identity_hash(target_data)
-        target_vertex = Vertex(target_data, hash_value=identity_hash)
+        target_vertex = create_osm_node_vertex(
+            node.id, time=vertex.get("time")
+        )
 
         # Create edge with cost based on walking time
         edge = Edge(
@@ -426,12 +417,7 @@ class OSMAccessProvider(CacheAwareEdgeProvider):
         if node is None:
             return None
 
-        node_data: dict[str, GraphserverDataType] = {
-            "osm_node_id": node.id,
-            **node.tags,
-        }
-        identity_hash = self._get_identity_hash(node_data)
-        return Vertex(node_data, hash_value=identity_hash)
+        return create_osm_node_vertex(node.id, tags=node.tags)
 
     @property
     def node_count(self) -> int:

--- a/python/src/graphserver/providers/osm/network_provider.py
+++ b/python/src/graphserver/providers/osm/network_provider.py
@@ -10,9 +10,10 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
-from graphserver.core import Edge, GraphserverDataType, Vertex, VertexEdgePair
+from graphserver.core import Edge, Vertex, VertexEdgePair
+from .utils import create_osm_node_vertex
 
 if TYPE_CHECKING:
     from .data_source import OSMDataSource
@@ -41,26 +42,6 @@ class OSMNetworkProvider:
             len(self.data_source.nodes),
             len(self.data_source.ways),
         )
-
-    def _get_identity_hash(
-        self, vertex_data: Mapping[str, GraphserverDataType]
-    ) -> int | None:
-        """Generate identity hash for vertex data.
-
-        Args:
-            vertex_data: Dictionary of vertex data
-
-        Returns:
-            Identity hash value or None if no hashable identity found
-        """
-        # Prioritize OSM node ID over coordinates if both are present
-        if "osm_node_id" in vertex_data:
-            hash_string = f"osm:{vertex_data['osm_node_id']}"
-        else:
-            return None
-
-        # Convert string to stable unsigned integer hash
-        return hash(hash_string) & 0xFFFFFFFFFFFFFFFF
 
     def out_edges(self, vertex: Vertex) -> Sequence[VertexEdgePair]:
         """Generate outgoing edges from an OSM node (implements EdgeProvider protocol).
@@ -169,12 +150,7 @@ class OSMNetworkProvider:
                 final_cost = walking_profile.get_edge_cost(temp_edge, way)
 
                 # Create target vertex
-                target_data = {
-                    "osm_node_id": target_node.id,
-                }
-                # Create target vertex with identity hash
-                identity_hash = self._get_identity_hash(target_data)
-                target_vertex = Vertex(target_data, hash_value=identity_hash)
+                target_vertex = create_osm_node_vertex(target_node.id)
 
                 # Create edge
                 metadata = {
@@ -205,13 +181,7 @@ class OSMNetworkProvider:
             return None
 
         node = self.data_source.nodes[node_id]
-        node_data: dict[str, GraphserverDataType] = {
-            "osm_node_id": node.id,
-            **node.tags,
-        }
-        # Create vertex with identity hash
-        identity_hash = self._get_identity_hash(node_data)
-        return Vertex(node_data, hash_value=identity_hash)
+        return create_osm_node_vertex(node.id, tags=node.tags)
 
     @property
     def node_count(self) -> int:
@@ -270,13 +240,7 @@ class OSMNetworkProvider:
             if max_vertices is not None and count >= max_vertices:
                 break
 
-            node_data: dict[str, GraphserverDataType] = {
-                "osm_node_id": node.id,
-                **node.tags,
-            }
-            # Create vertex with identity hash
-            identity_hash = self._get_identity_hash(node_data)
-            vertex = Vertex(node_data, hash_value=identity_hash)
+            vertex = create_osm_node_vertex(node.id, tags=node.tags)
             vertices.append(vertex)
 
         return vertices

--- a/python/src/graphserver/providers/osm/utils.py
+++ b/python/src/graphserver/providers/osm/utils.py
@@ -1,0 +1,33 @@
+"""Utility functions for OSM providers."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from graphserver.core import GraphserverDataType, Vertex
+
+
+def create_osm_node_vertex(
+    node_id: int,
+    *,
+    tags: Mapping[str, GraphserverDataType] | None = None,
+    time: GraphserverDataType | None = None,
+) -> Vertex:
+    """Create a standard OSM node vertex.
+
+    Args:
+        node_id: OSM node identifier
+        tags: Optional mapping of additional node attributes
+        time: Optional time value to include in the vertex
+
+    Returns:
+        Vertex instance with a stable identity hash based on the node ID
+    """
+    vertex_data: dict[str, GraphserverDataType] = {"osm_node_id": node_id}
+    if tags:
+        vertex_data.update(tags)
+    if time is not None:
+        vertex_data["time"] = time
+
+    identity_hash = hash(f"osm:{node_id}") & 0xFFFFFFFFFFFFFFFF
+    return Vertex(vertex_data, hash_value=identity_hash)


### PR DESCRIPTION
## Summary
- add shared `create_osm_node_vertex` helper
- replace duplicated OSM vertex construction in access and network providers

## Testing
- `pip install osmium`
- `pip install rtree pyproj shapely`
- `PYTHONPATH=python/src pytest python/tests -q` *(fails: C extension not available)*

------
https://chatgpt.com/codex/tasks/task_e_68941b418088833281c9b53a38adf629